### PR TITLE
docs(task-1): fix queue argument in task1 documentation

### DIFF
--- a/assignments/task-001/task-001.md
+++ b/assignments/task-001/task-001.md
@@ -33,7 +33,7 @@ You should repeat the assignment applying the following four scenarios:
    most challenging network scenario you can think of that can still complete
    the TCP connection, delivering the same amount of bytes as the previous
    scenarios? In addition to delay, bandwidth and loss rate, you can also limit
-   the packet queue size at the bottleneck link (argument `max_queue_size`).
+   the packet queue size at the bottleneck link (argument `queue`).
 
 Write a report that describes the following details. The report, and
 answers to the following questions need to be submitted


### PR DESCRIPTION
Change the argument `max_queue_size` to `queue` in the documentation, as the script uses `queue` argument (see https://github.com/PasiSa/mininet/blob/master/aalto/simple_topo.py#L44)

FYI: @PasiSa 