### PR TITLE
fix: grammar and typo corrections in task-002 documentation

### DIFF
--- a/assignments/task-002/task-002.md
+++ b/assignments/task-002/task-002.md
@@ -1,6 +1,6 @@
 # Task 2: TCP server
 
-In this assignment you will implement TCP server the gets incoming connection
+In this assignment, you will implement a TCP server that gets incoming connection
 requests and should send a number of bytes as requested by the client.
 
 The course git repository contains [Rust
@@ -13,8 +13,8 @@ Follow these steps in your program:
    choose a port number between 1024 and 49151
 
 2. Send a control message to the _adnet-agent_ server that follows this form:
-   `TASK-002 keyword IP:port`. As in previous task, _keyword_ is a random word
-   you receive in MyCourses assignment. _IP_ is the IP
+   `TASK-002 keyword IP:port`. As in the previous task, _keyword_ is a random word
+   you receive in the MyCourses assignment. _IP_ is the IP
    address your program runs at listening to incoming connections, and _port_ is
    the port that you chose to bind for listening. If you
    are running your program in node "lh1" of our `simple_topo` Mininet
@@ -22,47 +22,47 @@ Follow these steps in your program:
 
 3. _adnet-agent_ starts opening connections to your server. There will be
    altogether **three concurrent connections**. A client first sends 5
-   bytes of data. First four bytes is a **32-bit unsigned integer** in network
-   (big-endian) byte order. This tells how many bytes the agent excepts to
+   bytes of data. The first four bytes are a **32-bit unsigned integer** in network
+   (big-endian) byte order. This tells how many bytes the agent expects to
    receive from this socket. You should send this many bytes, all containing the
-   value that is indicated by the fifth byte in request from _adnet-agent_. Note
+   value indicated by the fifth byte in the request from _adnet-agent_. Note
    that your implementation should be prepared to handle multiple connections in
    parallel.
 
 4. When you have finished sending the requested number of bytes, you should
-   output the following to terminal: "`Wrote N bytes of byte B`". A new
-   request may arrive from a client, with similar 5-byte format, to which
+   output the following to the terminal: "`Wrote N bytes of byte B`". A new
+   request may arrive from a client, with a similar 5-byte format, to which
    you should respond in the same way as described above. If a client does
    not need more data from this socket, it closes the TCP connection. Your
-   program should therefore be able to handle closing TCP connection without
-   problems. Not that while one connection closes, there may be other
+   program should therefore be able to handle closing a TCP connection without
+   problems. Note that while one connection closes, there may be other
    connections still open, performing transmission.
 
-5. When _adnet-agent_ has closed all connections it opened in the beginning,
+5. When _adnet-agent_ has closed all the connections it opened at the beginning,
    this assignment is complete and successful.
 
-The below diagram illustrates the expected communication between your
+The diagram below illustrates the expected communication between your
 implementation and _adnet-agent_.
 
 ![Communication](comms.png "Communication")
 
-Execute your program and the _adnet-agent_ in Mininet `simple_topo` topology. As
-in previous assignment, _adnet-agent_ should run in host "_rh1_", and your
+Execute your program and the _adnet-agent_ in the Mininet `simple_topo` topology. As
+in the previous assignment, _adnet-agent_ should run in host "_rh1_", and your
 implementation should run in host "_lh1_". Run your implementation in Mininet
-configuration with following properties: `sudo aalto/simple_topo.py --delay=50ms
+configuration with the following properties: `sudo aalto/simple_topo.py --delay=50ms
 --bw=0.5`. You can also try other scenarios if you are interested.
 
-You should submit to MyCourses the output of your program, consisting multiple
-lines of the above mentioned "`Wrote N bytes of byte B`" messages.
+You should submit the output of your program to MyCourses, consisting of multiple
+lines of the above-mentioned "`Wrote N bytes of byte B`" messages.
 
 ## Tips
 
 - In Rust you can convert unsigned 32-bit integer (u32 type) into big-endian
-  4-byte array using function `to_be_bytes`
+  4-byte array using the `to_be_bytes` function
   ([example](https://doc.rust-lang.org/std/primitive.u32.html#method.to_be_bytes)),
-  and vice versa using `from_be_bytes`
+  and vice versa using the `from_be_bytes` function
   ([example](https://doc.rust-lang.org/std/primitive.u32.html#method.from_be_bytes))
 
-- See the different server **[examples](https://pasisa.github.io/AdvancedNetworking/examples/)** for different
+- See the different server **[examples](https://pasisa.github.io/AdvancedNetworking/examples/)** for various
   design alternatives (non-blocking events, thread-based, collaborative
   multitasking). Which one would be most suitable in this case?


### PR DESCRIPTION
This PR fixes grammar and typo issues in the documentation related to task-002.

@PasiSa 